### PR TITLE
Updated pause.until() to use logarithmic sleeping

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Precision
 
 The precision *should* be within 0.001 of a second, however, this will depend on how precise your system sleep is and other performance factors.
 
-This module checks the time at various intervals depending on how much time is left on the pause. If there is at least 1.5 seconds left, it will check every second. When the timer gets down to 0.1 seconds, the time will be checked every 0.001 second.
+This module computes the pause duration between now and the future date, and then sleeps for half of this duration. After this time, it recomputes the new pause duration, repeating this process until the desired time is reached.
 
 Install
 -------

--- a/pause/__init__.py
+++ b/pause/__init__.py
@@ -60,26 +60,8 @@ def until(time):
         #
         if diff <= 0:
             break
-
-        #
-        # Let's try to tune the precision, as we get closer to the end time
-        #
-
-        # Sleep by 0.001, when we're within 0.1 seconds
-        if diff <= 0.1:
-            sleep(0.001)
-
-        # Sleep by 0.01, when we're within 0.5 seconds
-        elif diff <= 0.5:
-            sleep(0.01)
-
-        # Sleep by 0.1, when we're within 1.5 seconds
-        elif diff <= 1.5:
-            sleep(0.1)
-
-        # Otherwise sleep by 1 second
         else:
-            sleep(1)
+            sleep(diff.total_seconds() / 2)
 
 
 def milliseconds(num):

--- a/pause/__init__.py
+++ b/pause/__init__.py
@@ -61,6 +61,7 @@ def until(time):
         if diff <= 0:
             break
         else:
+            # 'logarithmic' sleeping to minimize loop iterations
             sleep(diff / 2)
 
 

--- a/pause/__init__.py
+++ b/pause/__init__.py
@@ -61,7 +61,7 @@ def until(time):
         if diff <= 0:
             break
         else:
-            sleep(diff.total_seconds() / 2)
+            sleep(diff / 2)
 
 
 def milliseconds(num):


### PR DESCRIPTION
It seems unnecessary to sleep and recheck the time every second for longer pauses, especially when a pause may be held for weeks at a time. The proposed change implements "logarithmic sleeping", in which the system will sleep for half of the remaining duration until the desired time is reached.