### PR TITLE
Timezone handling on Python3

### DIFF
--- a/pause/__init__.py
+++ b/pause/__init__.py
@@ -29,10 +29,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import sys
 from datetime import datetime
 import time as pytime
 from time import sleep
-
+if sys.version_info[0] >= 3:
+            from datetime import timezone
 
 def until(time):
     """
@@ -43,8 +45,12 @@ def until(time):
 
     # Convert datetime to unix timestamp and adjust for locality
     if isinstance(time, datetime):
-        zoneDiff = pytime.time() - (datetime.now()- datetime(1970, 1, 1)).total_seconds()
-        end = (time - datetime(1970, 1, 1)).total_seconds() + zoneDiff
+        # If we're on Python 3 and the user specified a timezone, convert to UTC and get tje timestamp.
+        if sys.version_info[0] >= 3 and time.tzinfo:
+            end = time.astimezone(timezone.utc).timestamp()
+        else:
+            zoneDiff = pytime.time() - (datetime.now()- datetime(1970, 1, 1)).total_seconds()
+            end = (time - datetime(1970, 1, 1)).total_seconds() + zoneDiff
 
     # Type check
     if not isinstance(end, (int, float)):

--- a/pause/tests/test_pause.py
+++ b/pause/tests/test_pause.py
@@ -114,6 +114,22 @@ class TestPauseFor(unittest.TestCase):
         diff = now - startDate
         self.assertEqual(diff.seconds, 7)
 
+    def test_timezone(self):
+        """ test_datetime
+        Test 7 seconds, with a datetime object
+        """
+        if sys.version_info[0] >= 3:
+            from datetime import timezone
+			# Apply a timezone offset, Line Islands Time for fun
+            startDate = datetime.now(timezone(timedelta(hours=14), 'LINT'))
+            toDate = startDate + timedelta(seconds=7)
+            pause.until(toDate)
+            now = datetime.now(timezone.utc)
+
+            # True if at least 7 seconds has passed
+            diff = now - startDate
+            self.assertEqual(diff.seconds, 7)
+
     def test_timestamp(self):
         """ test_timestamp
         Test 6 seconds, with a unix timestamp

--- a/pause/tests/test_pause.py
+++ b/pause/tests/test_pause.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 #
+from __future__ import print_function
 
 import sys
 import math
@@ -47,7 +48,7 @@ class TestPauseFor(unittest.TestCase):
         #
         # True if it's within 0.1 of the target time
         #
-        print 'Milliseconds came within {0} seconds of 0.5'.format(target)
+        print('Milliseconds came within {0} seconds of 0.5'.format(target))
         valid = (target <= 0.1)
         self.assertTrue(valid)
 


### PR DESCRIPTION
Fixes an issue where module would throw ```can't subtract offset-naive and offset-aware datetimes``` when a datetime with a timezone was passed.

Also fixed test_pause.py on Python3